### PR TITLE
Open containing folder after extract

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -17,12 +17,6 @@
                         [
                             {
                                 "command": "open_file",
-                                "args": {"file": "${packages}/PackageResourceViewer/README.md"},
-                                "caption": "README"
-                            },
-                            { "caption": "-" },
-                            {
-                                "command": "open_file",
                                 "args": {"file": "${packages}/PackageResourceViewer/PackageResourceViewer.sublime-settings"},
                                 "caption": "Settings – Default"
                             },

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -13,19 +13,11 @@
                 [
                     {
                         "caption": "PackageResourceViewer",
-                        "children":
-                        [
-                            {
-                                "command": "open_file",
-                                "args": {"file": "${packages}/PackageResourceViewer/PackageResourceViewer.sublime-settings"},
-                                "caption": "Settings – Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {"file": "${packages}/User/PackageResourceViewer.sublime-settings"},
-                                "caption": "Settings – User"
-                            }
-                        ]
+                        "command": "edit_settings",
+                        "args": {
+                            "base_file": "${packages}/PackageResourceViewer/PackageResourceViewer.sublime-settings",
+                            "default": "// Your settings for PackageResourceViewer. See the default file to see the different options. \n{\n\t$0\n}\n"
+                        }
                     }
                 ]
             }

--- a/PackageResourceViewer.sublime-settings
+++ b/PackageResourceViewer.sublime-settings
@@ -15,5 +15,9 @@
 
     // True if, when moving up a directory, you would like the previous
     // selection to be automatically chosen. False otherwise.
-    "return_to_previous": false
+    "return_to_previous": false,
+
+    // If set to true, it will open the containing folder after you
+    // extracted it.
+    "open_containing_folder_after_extracting": false 
 }

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Boolean setting specifying if a single command should be listed in the command p
 
 True if, when moving up a directory, you would like the previous selection to be automatically chosen. False otherwise.
 
+# Open this readme quickly
+
+There is a little package that will do this really quickly for you, and, he's got a really cute name: [Readme​Please](https://packagecontrol.io/packages/ReadmePlease).
+
 # License
 
 The MIT License (MIT)

--- a/package_resource_viewer.py
+++ b/package_resource_viewer.py
@@ -231,6 +231,10 @@ class ExtractPackageCommand(sublime_plugin.WindowCommand):
         if index == -1:
             return
         extract_package(self.packages[index])
+        if self.settings.get('open_containing_folder_after_extracting', False) is True:
+            path = os.path.join(sublime.packages_path(), self.packages[index])
+            self.window.run_command('open_dir', { 'dir': path })
+            print('opened_dir {} - {}'.format(path, os.path.isdir(path)))
 
     def show_quick_panel(self, options, done_callback):
         sublime.set_timeout(lambda: self.window.show_quick_panel(options, done_callback), 10)


### PR DESCRIPTION
Hi!

I added a simple feature: **when you extract a package, it opens the containing folder for you**.

I added a setting to enable it (default to `false` to keep the default behavior), and I updated the menu: it uses the `edit_settings` command (open a new window splited in half with the default on the left and the users on the right). I also removed the `open readme`, to make people use [Readme​Please](https://packagecontrol.io/packages/ReadmePlease) (guess you didn't know it, try it, it's really cool)

Hope you'll accept it, but if there's any problem, just tell me, I'll try to fix them.

Thanks for your plugin anyway. 👍 😄 

Matt