### PR TITLE
Adding ignore_packages preference option

### DIFF
--- a/PackageResourceViewer.sublime-settings
+++ b/PackageResourceViewer.sublime-settings
@@ -1,19 +1,30 @@
 {
+	// List of packages to ignore, Package Control is ignored by default
+	// because extracting it cause errors
+	"ignored_packages" : [
+		"Package Control",
+		"0_packagesmanager_loader",
+		"0_package_control_loader",
+		"0_settings_loader"
+	],
+
 	// A list of regular expressions patterns to ignore. Note that
 	// these regular expressions are compared against the file or
 	// directory name.
-	"ignore_patterns": ["\\.(git|hg|svn|DS_Store)"],
+	"ignore_patterns": [
+		"\\.(git|hg|svn|DS_Store)"
+	],
 
 	// Boolean setting to keep selection panel open after selecting a
 	// resource to open.
 	"open_multiple": true,
 
-    // Boolean setting specifying if a single command should be listed
-    // in the command palette for viewing and editing files or
-    // if multiple commands should be used.
-    "single_command": true,
+	// Boolean setting specifying if a single command should be listed
+	// in the command palette for viewing and editing files or
+	// if multiple commands should be used.
+	"single_command": true,
 
-    // True if, when moving up a directory, you would like the previous
-    // selection to be automatically chosen. False otherwise.
-    "return_to_previous": false
+	// True if, when moving up a directory, you would like the previous
+	// selection to be automatically chosen. False otherwise.
+	"return_to_previous": false
 }

--- a/package_resource_viewer.py
+++ b/package_resource_viewer.py
@@ -5,7 +5,7 @@ import threading
 import errno
 
 VERSION = int(sublime.version())
-IS_ST3 = VERSION >=3006
+IS_ST3 = VERSION >= 3006
 if IS_ST3:
     from PackageResourceViewer.package_resources import *
 else:
@@ -47,7 +47,6 @@ class PackageResourceViewerBase(sublime_plugin.WindowCommand):
             return
 
         self.package = self.packages[index]
-        ignore_patterns = self.settings.get("ignore_patterns", [])
         self.package_files = {}
         self.quick_panel_files = self.create_quick_panel_file_list(self.package_files)
         self.add_entry_to_path_obj()

--- a/package_resources.py
+++ b/package_resources.py
@@ -185,28 +185,24 @@ def get_packages_list(ignore_packages=True, ignore_patterns=[]):
         executable_package_path = os.path.dirname(sublime.executable_path()) + os.sep + "Packages"
         package_set.update(_get_packages_from_directory(executable_package_path, ".sublime-package"))
 
-
+    ignore_set = []
     if ignore_packages:
-        ignored_list = sublime.load_settings(
-            "Preferences.sublime-settings").get("ignored_packages", [])
-    else:
-        ignored_list = []
+        ignore_set = set(sublime.load_settings(
+            "PackageResourceViewer.sublime-settings").get("ignored_packages", []))
 
-    for package in package_set:
+    for package in list(package_set):
         for pattern in ignore_patterns:
             if re.match(pattern, package):
-                ignored_list.append(package)
+                package_set.discard(package)
                 break
-
-    for ignored in ignored_list:
-        package_set.discard(ignored)
+        if package in ignore_set:
+            package_set.discard(package)
 
     return sorted(list(package_set))
 
 def get_sublime_packages(ignore_packages=True, ignore_patterns=[]):
     package_list = get_packages_list(ignore_packages, ignore_patterns)
     extracted_list = _get_packages_from_directory(sublime.packages_path())
-    extracted_list.extend(['0_packagesmanager_loader', '0_package_control_loader', '0_settings_loader'])
     return [x for x in package_list if x not in extracted_list]
 
 def _get_packages_from_directory(directory, file_ext=""):


### PR DESCRIPTION
Fixes #25 

`ignored_packages` is a list of packages to ignore that contains `"Package Control"` by default.

Also moved `0_.*_loader` files to the ignored list, this way they can be removed and extracted without having to access the plugin source code (.py).